### PR TITLE
TD-304: Transform body type into turnover specific metric

### DIFF
--- a/proto/configurator.thrift
+++ b/proto/configurator.thrift
@@ -9,7 +9,6 @@ typedef base.ID LimitName
 typedef limiter_config.LimitConfigID LimitConfigID
 typedef limiter_config.ShardSize ShardSize
 typedef limiter_config.LimitConfig LimitConfig
-typedef limiter_config.LimitBodyType LimitBodyType
 typedef limiter_config.OperationLimitBehaviour OperationLimitBehaviour
 
 struct LimitCreateParams {
@@ -18,7 +17,6 @@ struct LimitCreateParams {
     /** Идентификатор набора настроек создаваемого лимата, в будущем идентификатор заменит структура конфигурации */
     3: optional LimitName name
     4: optional string description
-    5: optional LimitBodyType body_type
     6: optional OperationLimitBehaviour op_behaviour
 }
 

--- a/proto/configurator.thrift
+++ b/proto/configurator.thrift
@@ -9,6 +9,7 @@ typedef base.ID LimitName
 typedef limiter_config.LimitConfigID LimitConfigID
 typedef limiter_config.ShardSize ShardSize
 typedef limiter_config.LimitConfig LimitConfig
+typedef limiter_config.LimitBodyType LimitBodyType
 typedef limiter_config.OperationLimitBehaviour OperationLimitBehaviour
 
 struct LimitCreateParams {
@@ -17,6 +18,7 @@ struct LimitCreateParams {
     /** Идентификатор набора настроек создаваемого лимата, в будущем идентификатор заменит структура конфигурации */
     3: optional LimitName name
     4: optional string description
+    5: optional LimitBodyType body_type
     6: optional OperationLimitBehaviour op_behaviour
 }
 

--- a/proto/limiter_config.thrift
+++ b/proto/limiter_config.thrift
@@ -22,7 +22,6 @@ struct LimitConfigParams {
     5: required time_range.TimeRangeType time_range_type
     6: required LimitContextType context_type
     7: required LimitType type
-    2: optional LimitTurnoverMetric turnover_metric
     8: required LimitScope scope
     9: optional string description
     10: required OperationLimitBehaviour op_behaviour
@@ -37,10 +36,12 @@ struct LimitConfig {
     7: required time_range.TimeRangeType time_range_type
     11: required LimitContextType context_type
     8: optional LimitType type
-    4: optional LimitTurnoverMetric turnover_metric
     9: optional LimitScope scope
     10: optional string description
     12: optional OperationLimitBehaviour op_behaviour
+
+    // deprecated
+    4: optional LimitBodyType body_type_deprecated
 }
 
 struct OperationLimitBehaviour {
@@ -59,7 +60,13 @@ union LimitType {
     1: LimitTypeTurnover turnover
 }
 
-struct LimitTypeTurnover {}
+struct LimitTypeTurnover {
+    /**
+     * Metric to account turnover with.
+     * If undefined, equivalent to specifying `LimitTurnoverNumber`.
+     */
+    1: optional LimitTurnoverMetric metric
+}
 
 union LimitTurnoverMetric {
 
@@ -143,4 +150,14 @@ union Change {
 
 struct CreatedChange {
     1: required LimitConfig limit_config
+}
+
+/// Deprecated definitions
+
+union LimitBodyType {
+    2: LimitBodyTypeCash cash
+}
+
+struct LimitBodyTypeCash {
+    1: required CurrencySymbolicCode currency
 }

--- a/proto/limiter_config.thrift
+++ b/proto/limiter_config.thrift
@@ -17,12 +17,12 @@ typedef base.CurrencySymbolicCode CurrencySymbolicCode
 
 struct LimitConfigParams {
     1: required LimitConfigID id
+    2: required LimitBodyType body_type
     3: required Timestamp started_at
     4: required ShardSize shard_size
     5: required time_range.TimeRangeType time_range_type
     6: required LimitContextType context_type
     7: required LimitType type
-    2: optional LimitTurnoverMetric turnover_metric
     8: required LimitScope scope
     9: optional string description
     10: required OperationLimitBehaviour op_behaviour
@@ -32,12 +32,12 @@ struct LimitConfig {
     1: required LimitConfigID id
     2: required string processor_type
     3: required Timestamp created_at
+    4: required LimitBodyType body_type
     5: required Timestamp started_at
     6: required ShardSize shard_size
     7: required time_range.TimeRangeType time_range_type
     11: required LimitContextType context_type
     8: optional LimitType type
-    4: optional LimitTurnoverMetric turnover_metric
     9: optional LimitScope scope
     10: optional string description
     12: optional OperationLimitBehaviour op_behaviour
@@ -55,32 +55,25 @@ union OperationBehaviour {
 struct Subtraction {}
 struct Addition {}
 
+union LimitBodyType {
+    1: LimitBodyTypeAmount amount
+    2: LimitBodyTypeCash cash
+}
+
+struct LimitBodyTypeAmount {
+    /** Идентификатор метрики, которую необходимо считать при изменении лимита */
+    1: required string metric
+}
+struct LimitBodyTypeCash {
+    1: required CurrencySymbolicCode currency
+}
+
+
 union LimitType {
     1: LimitTypeTurnover turnover
 }
 
 struct LimitTypeTurnover {}
-
-union LimitTurnoverMetric {
-
-    /**
-     * Measure turnover over number of operations.
-     */
-    1: LimitTurnoverNumber number
-
-    /**
-     * Measure turnover over aggregate amount of operations denominated in a single currency.
-     * In the event operation's currency differs from limit's currency operation will be accounted
-     * with appropriate exchange rate fixed against operation's timestamp.
-     */
-    2: LimitTurnoverAmount amount
-
-}
-
-struct LimitTurnoverNumber {}
-struct LimitTurnoverAmount {
-    1: required CurrencySymbolicCode currency
-}
 
 union LimitScope {
 

--- a/proto/limiter_config.thrift
+++ b/proto/limiter_config.thrift
@@ -17,12 +17,12 @@ typedef base.CurrencySymbolicCode CurrencySymbolicCode
 
 struct LimitConfigParams {
     1: required LimitConfigID id
-    2: required LimitBodyType body_type
     3: required Timestamp started_at
     4: required ShardSize shard_size
     5: required time_range.TimeRangeType time_range_type
     6: required LimitContextType context_type
     7: required LimitType type
+    2: optional LimitTurnoverMetric turnover_metric
     8: required LimitScope scope
     9: optional string description
     10: required OperationLimitBehaviour op_behaviour
@@ -32,12 +32,12 @@ struct LimitConfig {
     1: required LimitConfigID id
     2: required string processor_type
     3: required Timestamp created_at
-    4: required LimitBodyType body_type
     5: required Timestamp started_at
     6: required ShardSize shard_size
     7: required time_range.TimeRangeType time_range_type
     11: required LimitContextType context_type
     8: optional LimitType type
+    4: optional LimitTurnoverMetric turnover_metric
     9: optional LimitScope scope
     10: optional string description
     12: optional OperationLimitBehaviour op_behaviour
@@ -55,25 +55,32 @@ union OperationBehaviour {
 struct Subtraction {}
 struct Addition {}
 
-union LimitBodyType {
-    1: LimitBodyTypeAmount amount
-    2: LimitBodyTypeCash cash
-}
-
-struct LimitBodyTypeAmount {
-    /** Идентификатор метрики, которую необходимо считать при изменении лимита */
-    1: required string metric
-}
-struct LimitBodyTypeCash {
-    1: required CurrencySymbolicCode currency
-}
-
-
 union LimitType {
     1: LimitTypeTurnover turnover
 }
 
 struct LimitTypeTurnover {}
+
+union LimitTurnoverMetric {
+
+    /**
+     * Measure turnover over number of operations.
+     */
+    1: LimitTurnoverNumber number
+
+    /**
+     * Measure turnover over aggregate amount of operations denominated in a single currency.
+     * In the event operation's currency differs from limit's currency operation will be accounted
+     * with appropriate exchange rate fixed against operation's timestamp.
+     */
+    2: LimitTurnoverAmount amount
+
+}
+
+struct LimitTurnoverNumber {}
+struct LimitTurnoverAmount {
+    1: required CurrencySymbolicCode currency
+}
 
 union LimitScope {
 

--- a/proto/limiter_config.thrift
+++ b/proto/limiter_config.thrift
@@ -17,12 +17,12 @@ typedef base.CurrencySymbolicCode CurrencySymbolicCode
 
 struct LimitConfigParams {
     1: required LimitConfigID id
-    2: required LimitBodyType body_type
     3: required Timestamp started_at
     4: required ShardSize shard_size
     5: required time_range.TimeRangeType time_range_type
     6: required LimitContextType context_type
     7: required LimitType type
+    2: optional LimitTurnoverMetric turnover_metric
     8: required LimitScope scope
     9: optional string description
     10: required OperationLimitBehaviour op_behaviour
@@ -32,12 +32,12 @@ struct LimitConfig {
     1: required LimitConfigID id
     2: required string processor_type
     3: required Timestamp created_at
-    4: required LimitBodyType body_type
     5: required Timestamp started_at
     6: required ShardSize shard_size
     7: required time_range.TimeRangeType time_range_type
     11: required LimitContextType context_type
     8: optional LimitType type
+    4: optional LimitTurnoverMetric turnover_metric
     9: optional LimitScope scope
     10: optional string description
     12: optional OperationLimitBehaviour op_behaviour
@@ -55,22 +55,32 @@ union OperationBehaviour {
 struct Subtraction {}
 struct Addition {}
 
-union LimitBodyType {
-    1: LimitBodyTypeAmount amount
-    2: LimitBodyTypeCash cash
-}
-
-struct LimitBodyTypeAmount {}
-struct LimitBodyTypeCash {
-    1: required CurrencySymbolicCode currency
-}
-
-
 union LimitType {
     1: LimitTypeTurnover turnover
 }
 
 struct LimitTypeTurnover {}
+
+union LimitTurnoverMetric {
+
+    /**
+     * Measure turnover over number of operations.
+     */
+    1: LimitTurnoverNumber number
+
+    /**
+     * Measure turnover over aggregate amount of operations denominated in a single currency.
+     * In the event operation's currency differs from limit's currency operation will be accounted
+     * with appropriate exchange rate fixed against operation's timestamp.
+     */
+    2: LimitTurnoverAmount amount
+
+}
+
+struct LimitTurnoverNumber {}
+struct LimitTurnoverAmount {
+    1: required CurrencySymbolicCode currency
+}
 
 union LimitScope {
 


### PR DESCRIPTION
Also redefine weakly defined _amount_ body type into turnover over _number_ of operations.